### PR TITLE
ci-cd: add storage copy from prod to stg in pipeline

### DIFF
--- a/.github/workflows/cd-azure-ca-qa.yml
+++ b/.github/workflows/cd-azure-ca-qa.yml
@@ -15,6 +15,7 @@ on:
     branches:
       - release/v*
       - hotfix/v*
+  workflow_dispatch:
 
 jobs:
   environment:
@@ -30,9 +31,23 @@ jobs:
         shell: bash
         run: |
           echo "Loading Environment Variables"
-    
+
+  copy-data:
+    needs: environment
+    uses: tech4humans-devops/CI-CD/.github/workflows/azure-storage-copy.yml@feature/storage-copy
+    with:
+      environment: Staging
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_STAGING }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID_STAGING }}
+      ORIGIN_STORAGE_ACCOUNT: ${{ vars.STORAGE_ACCOUNT_DEVELOP }}
+      TARGET_STORAGE_ACCOUNT: ${{ vars.STORAGE_ACCOUNT_STAGING }}
+      ORIGIN_CONTAINER_NAME: ${{ vars.BLOB_CONTAINER_NAME_DEVELOP }}
+      TARGET_CONTAINER_NAME: ${{ vars.BLOB_CONTAINER_NAME_STAGING }}
+
   call-deploy:
-    needs: environment 
+    needs: copy-data 
     uses: tech4ai/devops-reusable-workflows/.github/workflows/cd-docker-azure.yaml@v2.0.0
     with:
       container-app-name: ${{ needs.environment.outputs.app_name }}


### PR DESCRIPTION
## Improvement in the Deployment Pipeline: Enabling Manual Trigger and Adding Data Copy Job

### Description
This PR enhances the `.github/workflows/cd-azure-ca-qa.yml` file by introducing the following changes:

- **Manual Trigger:**  
  The `workflow_dispatch` event has been added to allow manual triggering of the workflow, facilitating on-demand testing and deployments.

- **Data Copy Job:**  
  A new job, `copy-data`, has been incorporated to copy data between Azure storage accounts (from development to staging) using a reusable workflow. This ensures that all necessary data is in place before deployment begins.

- **Deployment Sequencing:**  
  The `call-deploy` job now depends on the `copy-data` job, ensuring that data copying is completed before deployment is initiated.

### Type of Change
- [ ] Bugfix
- [x] Build-related changes
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please specify):

### Current Behavior
Currently, the deployment workflow is automatically triggered based on branch patterns (`release/v*` and `hotfix/v*`) and does not support manual execution. Additionally, there is no dedicated step for data copying, which could lead to inconsistencies between environments.

### New Behavior
- **Manual Trigger:**  
  The addition of `workflow_dispatch` enables manual execution of the workflow as needed.

- **Data Copy Job:**  
  The new `copy-data` job:
  - Leverages a reusable workflow to copy data from a development storage account to a staging storage account.
  - Utilizes the necessary parameters and secrets for authentication and environment specification.

- **Deployment Sequencing:**  
  By configuring the `call-deploy` job to depend on `copy-data`, the process ensures that the data copy step is successfully completed before the deployment starts, thus improving the reliability of the pipeline.